### PR TITLE
feat: initialize astro portfolio with glassmorphism

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 .vscode
+node_modules/

--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -1,0 +1,5 @@
+import { defineConfig } from 'astro/config';
+
+export default defineConfig({
+  site: 'https://diegofercri.dev',
+});

--- a/package.json
+++ b/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "myportfolio",
+  "type": "module",
+  "scripts": {
+    "dev": "astro dev",
+    "build": "astro build",
+    "preview": "astro preview"
+  },
+  "dependencies": {
+    "astro": "^4.0.0"
+  }
+}

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -1,0 +1,16 @@
+---
+import '../styles/glass.css';
+---
+<html lang="es">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Diego Ferreira | Portfolio</title>
+  </head>
+  <body>
+    <main class="glass-card">
+      <h1>Hola, soy Diego</h1>
+      <p>Desarrollador web. Bienvenido a mi portfolio.</p>
+    </main>
+  </body>
+</html>

--- a/src/styles/glass.css
+++ b/src/styles/glass.css
@@ -1,0 +1,36 @@
+:root {
+  --blur: 10px;
+  --glass-bg: rgba(255, 255, 255, 0.1);
+  --glass-border: rgba(255, 255, 255, 0.25);
+  --bg-gradient: linear-gradient(135deg, #20232a, #090a0f);
+  --text-color: #fff;
+}
+
+html, body {
+  height: 100%;
+}
+
+body {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  margin: 0;
+  background: var(--bg-gradient);
+  color: var(--text-color);
+  font-family: system-ui, sans-serif;
+}
+
+.glass-card {
+  background: var(--glass-bg);
+  border: 1px solid var(--glass-border);
+  border-radius: 16px;
+  padding: 2rem 3rem;
+  backdrop-filter: blur(var(--blur));
+  -webkit-backdrop-filter: blur(var(--blur));
+  box-shadow: 0 4px 30px rgba(0, 0, 0, 0.1);
+  text-align: center;
+}
+
+.glass-card h1 {
+  margin-bottom: 0.5rem;
+}


### PR DESCRIPTION
## Summary
- set up Astro configuration and package metadata
- add basic glassmorphism landing page
- ensure node modules ignored

## Testing
- `npm install` *(fails: 403 Forbidden)*
- `npm test` *(fails: Missing script "test")*
- `npm run build` *(fails: astro not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c6a642d3a8832d9a96a151cce981f6